### PR TITLE
Update Split function and remove unused frame from function

### DIFF
--- a/BugzillaQueryRenderer.php
+++ b/BugzillaQueryRenderer.php
@@ -143,7 +143,7 @@ class BugzillaQueryRenderer {
     $doGrouping=0;
     if ($this->query->getGroup()) {
       $doGrouping=1;
-      $groups=split(",",$this->query->getGroup());
+      $groups=explode(",",$this->query->getGroup());
       #
       # Prepare group counters
       #
@@ -598,7 +598,7 @@ class BugzillaQueryRenderer {
     $barArray=array();
     if (array_key_exists($this->query->get('bar'),
         $this->query->fieldValues)) {
-      foreach (split(",",
+      foreach (explode(",",
           $this->query->
             fieldValues[$this->query->get('bar')]) as $key) {
         $barArray[$key]=0;

--- a/BugzillaReports.php
+++ b/BugzillaReports.php
@@ -72,7 +72,7 @@ class BugzillaReports extends BMWExtension {
     $args = func_get_args();
     array_shift($args);
     $bugzillaReport = new BugzillaReports( $parser );
-    return array( $parser->recursiveTagParse( $bugzillaReport->render($args), $frame ), 'noparse' => true, 'isHTML' => true);
+    return array( $parser->recursiveTagParse( $bugzillaReport->render($args) ), 'noparse' => true, 'isHTML' => true);
   }
 
   public function render($args) {   

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ latest software versions.
 
 ## Supported versions
 
-* [MediaWiki](https://www.mediawiki.org/) 1.25 (probably a few older versions, too)
+* [MediaWiki](https://www.mediawiki.org/) 1.31 (probably a few older versions, too)
 * [Bugzilla](https://www.bugzilla.org/) 5.0 (version 4.4 works with
   [this older revision](https://github.com/nakal/mediawiki-bugzillareports/tree/17361a2439d5afdbb213ffc1c4575277b77f52ed))
 


### PR DESCRIPTION
Update split() to explode as split is no longer in PHP7.
Remove $frame from paserHookFunction as it was undefined,
updated readme to show tested Mediawiki version